### PR TITLE
Fix the wrong condition at AI attacking loop

### DIFF
--- a/src/main/java/cs361/battleships/models/Game.java
+++ b/src/main/java/cs361/battleships/models/Game.java
@@ -43,7 +43,7 @@ public class Game {
             // AI does random attacks, so it might attack the same spot twice
             // let it try until it gets it right
             opponentAttackResult = playersBoard.attack(randRow(), randCol());
-        } while(opponentAttackResult.getResult() != INVALID);
+        } while(opponentAttackResult.getResult() == INVALID);
 
         return true;
     }


### PR DESCRIPTION
The wrong condition will cause the AI to continue attacking until it gets a hit.
see issues #14.
It now fixed.